### PR TITLE
chore: temporarily make it work

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -1,8 +1,6 @@
-const escapeHtml = require('escape-html')
-// import escapeHtml from 'escape-html'
-// const prism = require('prismjs')
-// const loadLanguages = require('prismjs/components/index')
-// const { logger, chalk, escapeHtml } = require('@vuepress/shared-utils')
+import escapeHtml from 'escape-html'
+import prism from 'prismjs'
+// import loadLanguages from 'prismjs/components/index.js'
 
 // required to make embedded highlighting work...
 // loadLanguages(['markup', 'css', 'javascript'])
@@ -14,36 +12,34 @@ function wrap (code, lang) {
   return `<pre v-pre class="language-${lang}"><code>${code}</code></pre>`
 }
 
-module.exports = wrap
-
-// function highlightCode (str, lang) {
-//   if (!lang) {
-//     return wrap(str, 'text')
-//   }
-//   lang = lang.toLowerCase()
-//   const rawLang = lang
-//   if (lang === 'vue' || lang === 'html') {
-//     lang = 'markup'
-//   }
-//   if (lang === 'md') {
-//     lang = 'markdown'
-//   }
-//   if (lang === 'ts') {
-//     lang = 'typescript'
-//   }
-//   if (lang === 'py') {
-//     lang = 'python'
-//   }
-//   if (!prism.languages[lang]) {
-//     try {
-//       // loadLanguages([lang])
-//     } catch (e) {
-//       console.warn(`[vuepress] Syntax highlight for language "${lang}" is not supported.`)
-//     }
-//   }
-//   if (prism.languages[lang]) {
-//     const code = prism.highlight(str, prism.languages[lang], lang)
-//     return wrap(code, rawLang)
-//   }
-//   return wrap(str, 'text')
-// }
+export default function highlightCode (str, lang) {
+  if (!lang) {
+    return wrap(str, 'text')
+  }
+  lang = lang.toLowerCase()
+  const rawLang = lang
+  if (lang === 'vue' || lang === 'html') {
+    lang = 'markup'
+  }
+  if (lang === 'md') {
+    lang = 'markdown'
+  }
+  if (lang === 'ts') {
+    lang = 'typescript'
+  }
+  if (lang === 'py') {
+    lang = 'python'
+  }
+  if (!prism.languages[lang]) {
+    try {
+      // loadLanguages([lang])
+    } catch (e) {
+      console.warn(`[vuepress] Syntax highlight for language "${lang}" is not supported.`)
+    }
+  }
+  if (prism.languages[lang]) {
+    const code = prism.highlight(str, prism.languages[lang], lang)
+    return wrap(code, rawLang)
+  }
+  return wrap(str, 'text')
+}

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   "homepage": "https://github.com/posva/vuepress-plugin-example-preview#readme",
   "dependencies": {
     "focus-visible": "^4.1.5",
-    "raw-loader": "^0.5.1",
-    "webpack": "^4.22.0"
+    "raw-loader": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vue": "^2.5.17",
     "vue-jest": "^3.0.0",
     "vue-template-compiler": "^2.5.17",
-    "vuepress": "^1.0.0-alpha.13"
+    "vuepress": "^1.0.0-alpha.16"
   },
   "repository": {
     "type": "git",
@@ -72,6 +72,7 @@
   "homepage": "https://github.com/posva/vuepress-plugin-example-preview#readme",
   "dependencies": {
     "focus-visible": "^4.1.5",
-    "raw-loader": "^0.5.1"
+    "raw-loader": "^0.5.1",
+    "webpack": "^4.22.0"
   }
 }


### PR DESCRIPTION
Oh, such a great plugin! 👍

![image](https://user-images.githubusercontent.com/23133919/47521572-fd063700-d8c5-11e8-8981-e8b035954c7c.png)

But I'm going to talk about a sad story.

This is a temporary workaround for that VuePress doesn't work when we import CommonJS module at client side:

```
const loadLanguages = require('prismjs/components/index') // A CommonJS module
```

This is a known weird issue, and I spent a lot of time on webpack and babel's repo to do research but couldn't find the answer, which caused us cannot share the same CommonJS format code on the server side and the client, so that VuePress had such a internal plugin for now 🙃:

https://github.com/vuejs/vuepress/blob/master/packages/%40vuepress/core/lib/internal-plugins/transformModule.js

I suspect that there is a problem with the babel configuration built into vuepress, but I haven't had time to continue the investigation. If you have any ideas, please let me know, thank you.